### PR TITLE
Fix color detection library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,12 @@ Arduino IDE -> Sketch -> Manage Library -> Search for missing Library
 It is important, before using any functions of Dezibot, to call ```dezibot.begin()``` once in the setup function.
 
 In the examples folder, a sketch ``start`` is provided, that handles the initialization.
+
+## Third-Party Licenses
+
+This project uses the following third-party libraries:
+
+- `veml6040` (version 0.3.2) by [@thewknd](https://github.com/thewknd) et al.
+    - Vishay VEML6040 RGBW color sensor library for Arduino
+    - Licensed under the MIT license
+    - For more information, see the [library's repository](https://github.com/thewknd/VEML6040/blob/master/LICENSE)

--- a/example/color_detection/color_detection.ino
+++ b/example/color_detection/color_detection.ino
@@ -1,0 +1,34 @@
+#include <Dezibot.h>
+
+#define READ_DELAY 500
+
+Dezibot dezibot = Dezibot();
+
+void setup() {
+  Serial.begin(115200);
+  dezibot.begin();
+}
+
+void loop() {
+  Serial.println("");
+  dezibot.display.clear();
+  
+  printValue(VEML_RED, "R");
+  printValue(VEML_GREEN, "G");
+  printValue(VEML_BLUE, "B");
+  printValue(VEML_WHITE, "W");
+
+  delay(READ_DELAY);
+}
+
+void printValue(color color, String prefix) {
+  uint16_t colorValue = dezibot.colorDetection.getColorValue(color);
+
+  dezibot.display.print(prefix);
+  dezibot.display.print(" ");
+  dezibot.display.println(colorValue);
+
+  Serial.print(prefix);
+  Serial.print(" ");
+  Serial.println(colorValue);
+}

--- a/library.properties
+++ b/library.properties
@@ -1,6 +1,6 @@
 name=Dezibot
-version=0.0.1
-author=Saskia Uta Duebener, Anton Jacker, Anina Ambra Morgner, Hans Felix Haupt, Jens Wagner, Mirella Willems
+version=0.0.2
+author=Saskia Uta Duebener, Anton Jacker, Anina Ambra Morgner, Hans Felix Haupt, Jens Wagner, Mirella Willems, Nico Schramm, Ines Rohrbach
 maintainer=Team Dezibot <info@dezibot.de>
 sentence= Allows the usage of the Dezibot4 Robot in Arduino.
 paragraph=

--- a/src/Dezibot.cpp
+++ b/src/Dezibot.cpp
@@ -14,9 +14,7 @@ void Dezibot::begin(void) {
     lightDetection.begin();    
     motion.begin();
     lightDetection.begin();
-    colorDetection.begin();
+    colorDetection.beginAutoMode();
     multiColorLight.begin();
     display.begin();
 };
-
-

--- a/src/colorDetection/ColorDetection.cpp
+++ b/src/colorDetection/ColorDetection.cpp
@@ -1,52 +1,58 @@
 #include  "ColorDetection.h"
 
-void ColorDetection::begin(void){
-    ColorDetection::configure(VEML_CONFIG{.mode = AUTO,.enabled = true,.exposureTime=MS40});
+void ColorDetection::beginAutoMode(void) {
+    const VEML_CONFIG DEFAULT_CONFIG = VEML_CONFIG {
+        .mode = AUTO,
+        .enabled = true,
+        .exposureTime = MS320 };
+    ColorDetection::configure(DEFAULT_CONFIG);
 };
-void ColorDetection::configure(VEML_CONFIG config){
-     uint8_t configRegister = 0;
-    switch(config.exposureTime)
-    {
+
+void ColorDetection::configure(VEML_CONFIG config) {
+    rgbwSensor.begin();
+
+    uint8_t configuration = 0;
+
+    switch(config.exposureTime) {
         case MS40:
-            configRegister = 0x00;break;
+            configuration += VEML6040_IT_40MS;
+            break;
         case MS80:
-            configRegister = 0x01;break;
+            configuration += VEML6040_IT_80MS;
+            break;
         case MS160:
-            configRegister = 0x02;break;
+            configuration += VEML6040_IT_160MS;
+            break;
         case MS320:
-            configRegister = 0x03;break;
+            configuration += VEML6040_IT_320MS;
+            break;
         case MS640:
-            configRegister = 0x04;break;
+            configuration += VEML6040_IT_640MS;
+            break;
         case MS1280:
-            configRegister = 0x05;break;
+            configuration += VEML6040_IT_1280MS;
+            break;
     }
-    configRegister = configRegister << 4;
-    if(config.mode == MANUAL)
-    {
-        configRegister = configRegister | (0x01<<1);
-    }
-    if(!config.enabled)
-    {
-        configRegister = configRegister | 1;
-    }
-    ColorDetection::writeDoubleRegister(CMD_CONFIG,(uint16_t)configRegister);
+
+    configuration += (config.mode == MANUAL) ? VEML6040_AF_FORCE : VEML6040_AF_AUTO;
+    configuration += config.enabled ? VEML6040_SD_ENABLE : VEML6040_SD_DISABLE;
+    
+    rgbwSensor.setConfiguration(configuration);
 };
 
 uint16_t ColorDetection::getColorValue(color color){
-   
-    switch(color)
-    {
+    switch(color) {
         case VEML_RED:
-            return readDoubleRegister(REG_RED); 
+            return rgbwSensor.getRed();
             break;
         case VEML_GREEN:
-            return readDoubleRegister(REG_GREEN);
+            return rgbwSensor.getGreen();
             break;
         case VEML_BLUE: 
-            return readDoubleRegister(REG_BLUE);
+            return rgbwSensor.getBlue();
             break;
         case VEML_WHITE:
-            return readDoubleRegister(REG_WHITE);
+            return rgbwSensor.getWhite();
             break;
         default:
             Serial.println("Color is not supported by the sensor");
@@ -54,30 +60,6 @@ uint16_t ColorDetection::getColorValue(color color){
     } 
 };
 
-uint16_t ColorDetection::readDoubleRegister(uint8_t regAddr){
-    uint16_t result = 0;
-    Wire.beginTransmission(VEML_ADDR);
-    Wire.write(regAddr);
-    if(Wire.endTransmission() != 0){
-        Serial.printf("Reading Register %d failed",regAddr);
-    }
-    Wire.requestFrom(VEML_ADDR,2);
-    uint8_t offset = 0;
-    while(Wire.available()){
-        result = result << 8;
-        result = result | (Wire.read()<<offset);
-        offset = offset + 8;
-    }
-    return result;
-};
-
-void ColorDetection::writeDoubleRegister(uint8_t regAddr, uint16_t data){
-    //erst low dann high
-    Wire.beginTransmission(VEML_ADDR);
-    Wire.write(regAddr);
-    Wire.write((uint8_t)(data&0x00FF));
-    Wire.write((uint8_t)((data>>8)&0x00FF));
-    if(Wire.endTransmission() != 0){
-        Serial.printf("Reading Register %d failed",regAddr);
-    }
+float ColorDetection::getAmbientLight() {
+    return rgbwSensor.getAmbientLight();
 };

--- a/src/colorDetection/ColorDetection.cpp
+++ b/src/colorDetection/ColorDetection.cpp
@@ -44,16 +44,12 @@ uint16_t ColorDetection::getColorValue(color color){
     switch(color) {
         case VEML_RED:
             return rgbwSensor.getRed();
-            break;
         case VEML_GREEN:
             return rgbwSensor.getGreen();
-            break;
         case VEML_BLUE: 
             return rgbwSensor.getBlue();
-            break;
         case VEML_WHITE:
             return rgbwSensor.getWhite();
-            break;
         default:
             Serial.println("Color is not supported by the sensor");
             return 0;

--- a/src/colorDetection/ColorDetection.h
+++ b/src/colorDetection/ColorDetection.h
@@ -1,9 +1,9 @@
 /**
  * @file ColorDetecion.h
- * @author Hans Haupt
- * @brief Class that controls the colorsensor (VEML6040) of the dezibot.
- * @version 0.1
- * @date 2024-06-01
+ * @author Nico Schramm, Ines Rohrbach, Hans Haupt
+ * @brief Class that controls the color sensor (VEML6040) of the dezibot.
+ * @version 0.2
+ * @date 2024-11-05
  * 
  * @copyright Copyright (c) 2024
  * 
@@ -11,25 +11,13 @@
 
 #ifndef ColorDetection_h
 #define ColorDetection_h
+
 #include <stdint.h>
 #include <Wire.h>
 #include <Arduino.h>
-//Definitions for I2c
-#define I2C_MASTER_SCL_IO           2      /*!< GPIO number used for I2C master clock */
-#define I2C_MASTER_SDA_IO           1      /*!< GPIO number used for I2C master data  */
+#include <veml6040.h>
 
-//Chipadress of the VEML6040
-#define VEML_ADDR                   0x10        /*!< Slave address of the MPU9250 sensor */
-
-//CMDCodes for communicate with the VEML6040
-#define CMD_CONFIG                  0x00
-#define REG_RED                     0x08
-#define REG_GREEN                   0x09
-#define REG_BLUE                    0x0A
-#define REG_WHITE                   0x0B
-
-
-enum duration{
+enum duration {
     MS40,
     MS80,
     MS160,
@@ -38,31 +26,60 @@ enum duration{
     MS1280
 };
 
-enum vemlMode{
+enum vemlMode {
     AUTO,
     MANUAL
 };
 
-struct VEML_CONFIG{
+struct VEML_CONFIG {
+    // force mode
     vemlMode mode;
+    
+    // chip shutdown setting
     bool enabled;
+    
+    // integration time
     duration exposureTime;
 };
 
-
-enum color{
+enum color {
     VEML_RED,
     VEML_GREEN,
     VEML_BLUE,
     VEML_WHITE
 };
-class ColorDetection{
-public: 
-    void begin(void);
+
+class ColorDetection {
+public:
+    /**
+     * @brief Start RBGW sensor with default configuration.
+     * 
+     */
+    void beginAutoMode(void);
+    
+    /**
+     * @brief Begin RGBW sensor with passed configuration values.
+     * 
+     * @param config configuration for VEML6040 sensor
+     */
     void configure(VEML_CONFIG config);
+
+    /**
+     * @brief Get color value of RGBW sensor.
+     * 
+     * @param color RGBW color which to get
+     * @return uint16_t color value
+     */
     uint16_t getColorValue(color color);
+
+    /**
+     * @brief Get the ambient light in lux.
+     * 
+     * @return float ambient light in lux.
+     */
+    float getAmbientLight();
+
 protected:
-    uint16_t readDoubleRegister(uint8_t regAddr);
-    void writeDoubleRegister(uint8_t regAddr, uint16_t data);
+    VEML6040 rgbwSensor;
 };
-#endif //ColorDetection_h
+#endif // ColorDetection_h

--- a/src/colorDetection/ColorDetection.h
+++ b/src/colorDetection/ColorDetection.h
@@ -2,6 +2,9 @@
  * @file ColorDetecion.h
  * @author Nico Schramm, Ines Rohrbach, Hans Haupt
  * @brief Class that controls the color sensor (VEML6040) of the dezibot.
+ * 
+ * This module uses the VEML6040 library (version 0.3.2) by thewknd (MIT license).
+ * 
  * @version 0.2
  * @date 2024-11-05
  * 

--- a/src/colorDetection/ColorDetection.h
+++ b/src/colorDetection/ColorDetection.h
@@ -58,7 +58,7 @@ public:
      * @brief Start RBGW sensor with default configuration.
      * 
      */
-    void beginAutoMode(void);
+    void beginAutoMode();
     
     /**
      * @brief Begin RGBW sensor with passed configuration values.

--- a/src/colorDetection/ColorDetection.h
+++ b/src/colorDetection/ColorDetection.h
@@ -82,4 +82,4 @@ public:
 protected:
     VEML6040 rgbwSensor;
 };
-#endif // ColorDetection_h
+#endif //ColorDetection_h


### PR DESCRIPTION
# Initial Problem
The `dezibot.colorDetection.getColorValue` method mostly returned the same colour value for all colours (i.e. red, green, blue, and white). This pull requests aims to fix that by using a third-party library for the RGBW sensor.

# Changes
- Re-implement `dezibot.colorDetection` methods using the [`VEML6040` library](https://github.com/thewknd/VEML6040/) (MIT license)
- Add ambient light method
- Rename `dezibot.colorDetection.begin()` to `dezibot.colorDetection.beginAutoMode()` for better clarity
- Add third-party license note to `README`
- Add doxygen documentation for new and re-implemented methods
- Add example sketch to test colour detection
- Remove methods that are not needed anymore

# How to Test
- Testable by running `example/color_detection/color_detection.ino`

# Further Notes
The changes suggested in this PR were researched and implemented in cooperation with @irooori.