### PR TITLE
Fix UB in FrequencyFindAFriend

### DIFF
--- a/example/advanced/FrequencyFindAFriend/FrequencyFindAFriend/FrequencyFindAFriend.ino
+++ b/example/advanced/FrequencyFindAFriend/FrequencyFindAFriend/FrequencyFindAFriend.ino
@@ -108,7 +108,7 @@ switch(brightest(magnitude)){
 }
 
 photoTransistors brightest(float *magnitudes){
-  int pos;
+  int pos = 0;
   float maxMagnitude = 0; 
   for(int index = 0; index <4; index++){
     if (magnitudes[index] > maxMagnitude){


### PR DESCRIPTION
If all 4 IR sensors report no amplitude, the index for the brightest sensor wont be initialized, often causing a crash