### PR TITLE
Minor Display class improvements; implement Battery class; implement Display::displayBattery

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,6 +1,6 @@
 name=Dezibot
-version=0.0.2
-author=Saskia Uta Duebener, Anton Jacker, Anina Ambra Morgner, Hans Felix Haupt, Jens Wagner, Mirella Willems, Nico Schramm, Ines Rohrbach
+version=0.0.3
+author=Saskia Uta Duebener, Anton Jacker, Anina Ambra Morgner, Hans Felix Haupt, Jens Wagner, Mirella Willems, Nico Schramm, Ines Rohrbach, Florian Schmidt
 maintainer=Team Dezibot <info@dezibot.de>
 sentence= Allows the usage of the Dezibot4 Robot in Arduino.
 paragraph=

--- a/src/Dezibot.cpp
+++ b/src/Dezibot.cpp
@@ -17,4 +17,5 @@ void Dezibot::begin(void) {
     colorDetection.beginAutoMode();
     multiColorLight.begin();
     display.begin();
+    battery.begin();
 };

--- a/src/Dezibot.h
+++ b/src/Dezibot.h
@@ -19,6 +19,7 @@
 #include "infraredLight/InfraredLight.h"
 #include "communication/Communication.h"
 #include "display/Display.h"
+#include "battery/Battery.h"
 
 
 class Dezibot {
@@ -33,6 +34,7 @@ public:
     InfraredLight infraredLight;
     Communication communication;
     Display display;
+    Battery battery;
     void begin(void);
 };
 

--- a/src/battery/Battery.cpp
+++ b/src/battery/Battery.cpp
@@ -18,7 +18,7 @@ void Battery::begin(void){
 };
 
 bool Battery::isCharging(void){
-    bool vusb_inv = (bool) digitalRead(VUSB_SENS_PIN);
+    bool vusb_inv = (bool)digitalRead(VUSB_SENS_PIN);
     return !vusb_inv;
 };
 

--- a/src/battery/Battery.cpp
+++ b/src/battery/Battery.cpp
@@ -1,0 +1,89 @@
+/**
+ * @file Battery.cpp
+ * @author Florian Schmidt
+ * @brief Implementation of the Battery class
+ * @version 0.1
+ * @date 2024-11-24
+ * 
+ * @copyright Copyright (c) 2023
+ * 
+ */
+
+#include "Battery.h"
+#include <Arduino.h>
+
+void Battery::begin(void){
+    pinMode(BAT_ADC_EN_PIN, OUTPUT);
+    pinMode(VUSB_SENS_PIN, INPUT_PULLUP);
+};
+
+bool Battery::isCharging(void){
+    bool vusb_inv = (bool) digitalRead(VUSB_SENS_PIN);
+    return !vusb_inv;
+};
+
+float Battery::getVoltage(void){
+    uint16_t adcValue = 0;
+    const uint8_t samples = 8; // ensure samples*4095 <= UINT16_MAX
+
+    digitalWrite(BAT_ADC_EN_PIN, HIGH);
+    for (int i = 0; i < samples; i++)
+    {
+        adcValue += analogRead(BAT_ADC_PIN);
+        ets_delay_us(125);
+    }
+    digitalWrite(BAT_ADC_EN_PIN, LOW);
+    
+    adcValue /= samples;
+
+    const float n = 57.5f;
+    const float fact = 3.4054f;
+    float vBat = ((static_cast<float>(adcValue) + n) / 4095) * fact * 3.7f;
+    return vBat;
+};
+
+uint8_t Battery::getBatteryLevel(void){
+    return voltsToBatLevel(getVoltage(), isCharging());
+};
+
+BatteryInfo Battery::getAll(void){
+    float vBat = getVoltage();
+    bool charging = isCharging();
+    uint8_t batteryLevel = voltsToBatLevel(vBat, charging);
+
+    BatteryInfo info;
+    info.charging = charging;
+    info.voltage = vBat;
+    info.batteryLevel = batteryLevel;
+    return info;
+}
+
+uint8_t Battery::voltsToBatLevel(float vBat, bool isCharging){
+    const float *coefficients;
+
+    switch (isCharging)
+    {
+    case true:
+        if (vBat < 3.57)
+            return 1;
+        if (vBat > 4.22)
+            return 100;
+        coefficients = CHARGE_COEFFS;
+        break;
+    case false:
+        if (vBat < 3.36)
+            return 1;
+        if (vBat > 4.13)
+            return 100;
+        coefficients = DISCHARGE_COEFFS;
+        break;
+    }
+    
+    // 5th order polynomial, this can definitely be optimized
+    // takes around 140 us to calculate
+    float level = coefficients[0] * pow(vBat, 5)+ coefficients[1] * pow(vBat, 4)
+    + coefficients[2] * pow(vBat, 3) + coefficients[3] * pow(vBat, 2)
+    + coefficients[4] * vBat + coefficients[5];
+
+    return static_cast<uint8_t>(round(level));
+};

--- a/src/battery/Battery.cpp
+++ b/src/battery/Battery.cpp
@@ -12,6 +12,11 @@
 #include "Battery.h"
 #include <Arduino.h>
 
+const float Battery::CHARGE_COEFFS[6] = {357.72441f, -5032.4026f,
+    24018.272f, -34322.036f, -47802.877f, 125260.37f};
+const float Battery::DISCHARGE_COEFFS[6] = {-266.14885f, 5549.0926f, -45814.116f,
+    187370.92f, -379715.32f, 305088.72f};
+
 void Battery::begin(void){
     pinMode(BAT_ADC_EN_PIN, OUTPUT);
     pinMode(VUSB_SENS_PIN, INPUT_PULLUP);

--- a/src/battery/Battery.h
+++ b/src/battery/Battery.h
@@ -1,0 +1,81 @@
+ /**
+ * @file Battery.h
+ * @author Florian Schmidt
+ * @brief Class for retrieving battery information, including voltage, approximate charge percentage,
+ * and power connection status for the Dezibot.
+ * @version 0.1
+ * @date 2024-11-24
+ * 
+ * @copyright Copyright (c) 2024
+ * 
+ */
+
+#ifndef Battery_h
+#define Battery_h
+
+#include <stdint.h>
+
+struct BatteryInfo {
+    bool charging;
+    float voltage;
+    uint8_t batteryLevel;
+};
+
+class Battery {
+public:
+    /**
+     * @brief Initialize gpio pins for battery monitoring
+     */
+    void begin();
+
+    /**
+     * @brief Check whether USB voltage is present
+     * (returns true even if charging is complete).
+     * 
+     * If the battery voltage is also required, use getAll() instead.
+     * 
+     * @return bool charger attached
+     */
+    bool isCharging();
+    
+    /**
+     * @brief Read the current voltage of the battery
+     * 
+     * If the battery voltage is also required, use getAll() instead.
+     * 
+     * @return float vBat (~3.2-4.2) 
+     */
+    float getVoltage();
+
+    /**
+     * @brief Approximate the current state of charge, compensating for charging/discharging voltages
+     * 
+     * If charging status/voltage is also required, use getAll() instead
+     * 
+     * @return uint8_t batteryLevel (1-100)
+     */
+    uint8_t getBatteryLevel();
+
+    /**
+     * @brief get all battery information at once (charging status, voltage, battery level).
+     * Should only be used when the battery level plus any other information is needed,
+     * as battery level approximation is expensive (but needs charging status and voltage regardless)
+     * 
+     * @return BatteryInfo {bool charging, float voltage, uint8_t batteryLevel}
+     */
+    BatteryInfo getAll();
+
+protected:
+    uint8_t voltsToBatLevel(float vBat, bool isCharging);
+    static inline uint8_t BAT_ADC_EN_PIN = 9;
+    static inline uint8_t BAT_ADC_PIN = 10;
+    static inline uint8_t VUSB_SENS_PIN = 38;
+    // when changing the length of coeff arrays, Battery::voltsToBatLevel() must be updated
+    static constexpr float CHARGE_COEFFS[6] = {357.72441f, -5032.4026f, 24018.272f, -34322.036f,
+    -47802.877f, 125260.37f};
+    // these coefficients are the most accurate for high batt loads (^= highest voltage drop)
+    static constexpr float DISCHARGE_COEFFS[6] = {-266.14885f, 5549.0926f, -45814.116f, 187370.92f,
+    -379715.32f, 305088.72f};
+};
+
+#endif //Battery_h

--- a/src/battery/Battery.h
+++ b/src/battery/Battery.h
@@ -70,12 +70,9 @@ protected:
     static inline uint8_t BAT_ADC_EN_PIN = 9;
     static inline uint8_t BAT_ADC_PIN = 10;
     static inline uint8_t VUSB_SENS_PIN = 38;
-    // when changing the length of coeff arrays, Battery::voltsToBatLevel() must be updated
-    static constexpr float CHARGE_COEFFS[6] = {357.72441f, -5032.4026f, 24018.272f, -34322.036f,
-    -47802.877f, 125260.37f};
-    // these coefficients are the most accurate for high batt loads (^= highest voltage drop)
-    static constexpr float DISCHARGE_COEFFS[6] = {-266.14885f, 5549.0926f, -45814.116f, 187370.92f,
-    -379715.32f, 305088.72f};
+    // when changing the declared lengths, their definitions and Battery::voltsToBatLevel() must be updated
+    static const float CHARGE_COEFFS[6];
+    static const float DISCHARGE_COEFFS[6];
 };
 
 #endif //Battery_h

--- a/src/display/Display.cpp
+++ b/src/display/Display.cpp
@@ -94,23 +94,22 @@ void Display::updateLine(uint charAmount)
 };
 
 void Display::print(char *value){
-    char *nextchar;
+    // char *nextchar;
 	/* write data to the buffer */
     while(value && *value != '\0') //check if pointer is still valid and string is not terminated 
         {
 	        //check if next character is a linebreak
             if(*value=='\n')
             {
-                //fill the current line with blanks
-                while(this->charsOnCurrLine<16)
-                {
-                    updateLine(1);
-                    Wire.beginTransmission(DisplayAdress);
-                    for(int i = 0;i<9;i++){
-                        Wire.write(font8x8_colwise[0][i]);
-                    }
-                    Wire.endTransmission();
-                }
+                // updateLine can be skipped, result will always be currLine++ and charsOnCL = 0
+                // skip to next line
+                Wire.beginTransmission(DisplayAdress);
+                Wire.write(0x00); // cmd mode
+                Wire.write(0xB0 | currLine+1); // set page start bit-OR next line
+                Wire.write(0x00); // lower column address (0 since newline)
+                Wire.write(0x10); // upper column address (still 0)
+                Wire.endTransmission();
+
                 //make the linebreak
                 this->currLine=currLine+1;
                 this->charsOnCurrLine=0;
@@ -231,4 +230,12 @@ void Display::displayBattery(uint8_t batteryLevel, BatteryLocation location){
         Wire.write(data_cmds[i]);
     };
     Wire.endTransmission();
+
+    // restore colRange/pageRange
+    ctrl_cmds[3] = 0x00;
+    ctrl_cmds[4] = 0x7f;
+    ctrl_cmds[6] = 0x00;
+    ctrl_cmds[7] = 0x07;
+
+    sendDisplayCMDs(ctrl_cmds, sizeof(ctrl_cmds));
 };

--- a/src/display/Display.cpp
+++ b/src/display/Display.cpp
@@ -101,11 +101,12 @@ void Display::print(char *value){
 	        //check if next character is a linebreak
             if(*value=='\n')
             {
-                // updateLine can be skipped, result will always be currLine++ and charsOnCL = 0
+                // updateLine can be skipped, only need to check 8+ overflow;
+                // otherwise result will always be currLine++ and charsOnCL = 0
                 // skip to next line
                 Wire.beginTransmission(DisplayAdress);
                 Wire.write(0x00); // cmd mode
-                Wire.write(0xB0 | currLine+1); // set page start bit-OR next line
+                Wire.write(0xB0 | (currLine+1) % 8); // set page start bit-OR next line
                 Wire.write(0x00); // lower column address (0 since newline)
                 Wire.write(0x10); // upper column address (still 0)
                 Wire.endTransmission();

--- a/src/display/Display.h
+++ b/src/display/Display.h
@@ -37,6 +37,15 @@ class Display{
         void sendDisplayCMD(uint8_t cmd);
 
         /**
+         * @brief Like sendDisplayCMD, but less I2C overhead when sending multiple 
+         * commands at once. cmd_count must be <= I2C_BUFFER_LENGTH - 1
+         * 
+         * @param cmds pointer to bytes of instructions
+         * @param cmd_count the amount of instructions
+         */
+        void sendDisplayCMDs(uint8_t *cmds, size_t cmd_count);
+
+        /**
          * @brief should be called whenever characters where printed to the display.
          * Updates the data of the class to handle linebreaks correctly
          * @param charAmount How many characters where added to the screen

--- a/src/display/Display.h
+++ b/src/display/Display.h
@@ -1,9 +1,9 @@
 /**
  * @file InfraredLight.h
- * @author Hans Haupt (hans.haupt@dezibot.de)
+ * @author Hans Haupt (hans.haupt@dezibot.de), Florian Schmidt
  * @brief Adds the ability to print to the display of the robot.
- * @version 0.1
- * @date 2024-05-24
+ * @version 0.2
+ * @date 2024-11-24
  * 
  * @copyright Copyright (c) 2024
  * 
@@ -14,6 +14,13 @@
 #include <stdint.h>
 #include <Arduino.h>
 #include "DisplayCMDs.h"
+
+enum class BatteryLocation {
+    TOP_LEFT,
+    TOP_RIGHT,
+    BOTTOM_LEFT,
+    BOTTOM_RIGHT
+};
 
 class Display{
     protected:
@@ -130,6 +137,17 @@ class Display{
          * 
          */
         void invertColor(void);
+
+        /**
+         * @brief displays a battery icon on one of the corners
+         * 
+         * example:
+         * 
+         * @code
+         * dezibot.display.displayBattery(dezibot.battery.getBatteryLevel(), BatteryLocation::TOP_LEFT);
+         * @endcode
+         */
+        void displayBattery(uint8_t batteryLevel, BatteryLocation location);
 };
 
 

--- a/src/display/Display.h
+++ b/src/display/Display.h
@@ -139,15 +139,17 @@ class Display{
         void invertColor(void);
 
         /**
-         * @brief displays a battery icon on one of the corners
+         * @brief displays a battery icon on one of the corners.
+         * 
+         * Since display.print/println() overdraws the whole row, this function should be called last.
          * 
          * example:
          * 
          * @code
-         * dezibot.display.displayBattery(dezibot.battery.getBatteryLevel(), BatteryLocation::TOP_LEFT);
+         * dezibot.display.drawBattery(dezibot.battery.getBatteryLevel(), BatteryLocation::TOP_LEFT);
          * @endcode
          */
-        void displayBattery(uint8_t batteryLevel, BatteryLocation location);
+        void drawBattery(uint8_t batteryLevel, BatteryLocation location);
 };
 
 


### PR DESCRIPTION
Display changes:
* use I2C command batch in some cases
* fix 16 char overflow -> newline bug (incorrect mod17 instead of mod16)
* implement linebreak using control commands instead of blanking out remaining cols/pages
* Added `displayBattery()` method which accepts a battery percentage and one of the four corners
  * corner as enum better or worse than 'regular' constants?

Battery class:
* `bool isCharging()`
* `float getVoltage()`
* `uint8_t getBatteryLevel()`
  * battery level uses two curves (charging/discharging), discharge curve is calibrated for high load
  * both curves are somewhat inefficient polynomials
* `BatteryInfo getAll()`: returns all three, since batteryLevel requires charging state/voltage anyway